### PR TITLE
Enhancements in Slow Defense tab:

### DIFF
--- a/src/chrome/content/mainFrame.js
+++ b/src/chrome/content/mainFrame.js
@@ -443,19 +443,11 @@ com.rigantestools.MainFrame.showDefenseAllCastles = function() {
  * @this {MainFrame}
  * @return {Boolean} true if checked
  */
-com.rigantestools.MainFrame.getAttackDefenseSlowUnitTypeUO = function() {
-    return (this._util.getAttribute('rigantestools-attackDefenseSlowUnitType', 'value')!=='UD');
+com.rigantestools.MainFrame.getAttackDefenseSlowUnitType = function() {
+	return (this._util.getAttribute('rigantestools-attackDefenseSlowUnitType', 'value') );
 };
 
-/**
- * indicate if we use unit type UD
- * 
- * @this {MainFrame}
- * @return {Boolean} true if checked
- */
-com.rigantestools.MainFrame.getAttackDefenseSlowUnitTypeUD = function() {
-    return (this._util.getAttribute('rigantestools-attackDefenseSlowUnitType', 'value')!=='UO');
-};
+
 
 /**
  * indicate if we use all castles
@@ -467,6 +459,10 @@ com.rigantestools.MainFrame.getAttackDefenseSlowUsedAllCastles = function() {
     return this._util.getAttribute('rigantestools-defenseAttackDefenseSlowUsedAllCastles', 'checked');
 };
 
+com.rigantestools.MainFrame.getAttackDefenseSlowRalentit = function() {
+    return this._util.getAttribute('rigantestools-defenseAttackDefenseSlowRalentit', 'checked');
+};
+
 /**
  * get the unit count
  * 
@@ -474,8 +470,13 @@ com.rigantestools.MainFrame.getAttackDefenseSlowUsedAllCastles = function() {
  * @return {Number} the unit count
  */
 com.rigantestools.MainFrame.getAttackDefenseSlowUnitCount = function() {
-    return Number(this._util.getAttribute('rigantestools-attackDefenseSlowUnitCount', 'value'));
+	return Number(this._util.getAttribute('rigantestools-attackDefenseSlowUnitCount', 'value'));
 };
+
+com.rigantestools.MainFrame.getAttackDefenseSlowErrorMargin = function() {
+	return Number(this._util.getAttribute('rigantestools-attackDefenseSlowErrorMargin', 'value'));
+};
+
 
 
 
@@ -1054,7 +1055,7 @@ com.rigantestools.MainFrame.calculateSimulationAndShow = function() {
  * @return {Boolean} true if successful
  */
 com.rigantestools.MainFrame.calculateAttackDefenseSlowTimeAndShow = function() {
-    try {
+    //try {
         if (this._player === null) {
             return false;
         }
@@ -1075,13 +1076,18 @@ com.rigantestools.MainFrame.calculateAttackDefenseSlowTimeAndShow = function() {
             return false;
         }
         
-        var unitTypeUO = this.getAttackDefenseSlowUnitTypeUO();
-        var unitTypeUD = this.getAttackDefenseSlowUnitTypeUD();
-        var unitCount = this.getAttackDefenseSlowUnitCount();
-        var allCastles = this.getAttackDefenseSlowUsedAllCastles();
+ 		var unitType = this.getAttackDefenseSlowUnitType();
+		var unitCount = this.getAttackDefenseSlowUnitCount();
+		var allCastles = this.getAttackDefenseSlowUsedAllCastles();
+		var ralentit = this.getAttackDefenseSlowRalentit();
+		var errorMargin = this.getAttackDefenseSlowErrorMargin();
+		var onlyCastles = this._util.getAttribute('rigantestools-attackDefenseSlowOnlyCastles', 'value') ;
+		var noCastles = this._util.getAttribute('rigantestools-attackDefenseSlowNoCastles', 'value') ;
+        var maxperminute  = this._util.getAttribute('rigantestools-attackDefenseSlowMaxPerMinute', 'value') ;
+
         
         this.clearAttackDefenseSlowTab();
-        var slowAttackDefenseCalculate = new com.rigantestools_SlowAttackDefenseCalculate(this._player.getHabitatList(), targetLink, date, duration, unitTypeUD, unitTypeUO, unitCount, startTimeUnit, allCastles);
+        var slowAttackDefenseCalculate = new com.rigantestools_SlowAttackDefenseCalculate(this._player.getHabitatList(), targetLink, date, duration, unitType, unitCount, startTimeUnit, allCastles, errorMargin, onlyCastles, noCastles, ralentit, maxperminute);
         this.currentHabitatsAttackDefenseSlow = slowAttackDefenseCalculate.getResultList();
         this.sortcolumnAttackDefenseSlowTree(null);
         
@@ -1097,11 +1103,11 @@ com.rigantestools.MainFrame.calculateAttackDefenseSlowTimeAndShow = function() {
         this._util.setAttribute('rigantestools-attackDefenseSlowInfoStartTimeTargetMax', 'value', this._util.formatDateTime(slowAttackDefenseCalculate.getStartTimeTargetMax()));
         this._util.setAttribute('rigantestools-attackDefenseSlowInfoStartTimeTargetMin', 'value', this._util.formatDateTime(slowAttackDefenseCalculate.getStartTimeTargetMin()));
         this._util.setVisibility('rigantestools-attackDefenseSlowActionBar', 'visible');
-    }
-    catch(e) {
-        this._logger.error("calculateAttackDefenseSlowTimeAndShow = "+e);
-        this._util.showMessage(this._util.getBundleString("error"), this._util.getBundleString("error.data.not.found"));
-    }
+    //}
+    //catch(e) {
+    //    this._logger.error("calculateAttackDefenseSlowTimeAndShow = "+e);
+    //    this._util.showMessage(this._util.getBundleString("error"), this._util.getBundleString("error.data.not.found"));
+    //}
 };
 
 /**
@@ -2432,54 +2438,54 @@ com.rigantestools.MainFrame.refreshDefenseTree = function() {
  * @this {MainFrame}
  */
 com.rigantestools.MainFrame.refreshAttackDefenseSlowTree = function() {
-    this.clearAttackDefenseSlowTree();
-    var treeChildren = document.getElementById("rigantestools-attackDefenseSlow-treechildren");
-    for (var index = 0; index < this.currentHabitatsAttackDefenseSlow.length; index++) {
-        var item = this.currentHabitatsAttackDefenseSlow[index];
-        var properties = '';
+	this.clearAttackDefenseSlowTree();
+	var treeChildren = document.getElementById("rigantestools-attackDefenseSlow-treechildren");
+	for ( var index = 0; index < this.currentHabitatsAttackDefenseSlow.length; index++) {
+		var item = this.currentHabitatsAttackDefenseSlow[index];
+		var properties = '';
         if(index%2) {
             properties = 'inGrey';
         }
         var treerow = [ "xul:treerow", { properties : properties }];
-        for (var row in item) {
-            if(row.indexOf("Date")>=0) { 
-                treerow.push([ "xul:treecell", {label : this._util.formatDateTime(item[row])} ]);
-            } 
-            else if(row==="unitType"){
-                var unit = "";
-                switch(item[row]) {
-                    case com.rigantestools_Constant.UNITTYPE.SPEARMAN: 
-                        unit = this._util.getBundleString("mainframe.attackDefenseSlow.Spearman");
-                        break;
-                    case com.rigantestools_Constant.UNITTYPE.SWORDMAN:
-                        unit = this._util.getBundleString("mainframe.attackDefenseSlow.Swordman");
-                        break;
-                    case com.rigantestools_Constant.UNITTYPE.ARCHER:
-                        unit = this._util.getBundleString("mainframe.attackDefenseSlow.Archer");
-                        break;
-                    case com.rigantestools_Constant.UNITTYPE.CROSSBOWMAN:
-                        unit = this._util.getBundleString("mainframe.attackDefenseSlow.Crossbowman");
-                        break;
-                    case com.rigantestools_Constant.UNITTYPE.SCORPIONRIDER:
-                        unit = this._util.getBundleString("mainframe.attackDefenseSlow.ScorpionRider");
-                        break;
-                    case com.rigantestools_Constant.UNITTYPE.LANCER:
-                        unit = this._util.getBundleString("mainframe.attackDefenseSlow.Lancer");
-                        break;
-                    default:
-                        
-                }
-                treerow.push([ "xul:treecell", {label : unit} ]);
-            }
-            else {
-                treerow.push([ "xul:treecell", {label : item[row]} ]);
-            }
-            
-        }
-        // generate treeitem element
+		for (var row in item) {
+			if(row.indexOf("Date")>=0) { 
+				treerow.push([ "xul:treecell", {label : this._util.formatDateTime(item[row])} ]);
+			} 
+			else if(row==="unitType" || row==="ralentUnitType"){
+				var unit = "";
+				switch(item[row]) {
+					case com.rigantestools_Constant.UNITTYPE.SPEARMAN: 
+						unit = this._util.getBundleString("mainframe.attackDefenseSlow.Spearman");
+						break;
+					case com.rigantestools_Constant.UNITTYPE.SWORDMAN:
+						unit = this._util.getBundleString("mainframe.attackDefenseSlow.Swordman");
+						break;
+					case com.rigantestools_Constant.UNITTYPE.ARCHER:
+						unit = this._util.getBundleString("mainframe.attackDefenseSlow.Archer");
+						break;
+					case com.rigantestools_Constant.UNITTYPE.CROSSBOWMAN:
+						unit = this._util.getBundleString("mainframe.attackDefenseSlow.Crossbowman");
+						break;
+					case com.rigantestools_Constant.UNITTYPE.SCORPIONRIDER:
+						unit = this._util.getBundleString("mainframe.attackDefenseSlow.ScorpionRider");
+						break;
+					case com.rigantestools_Constant.UNITTYPE.LANCER:
+						unit = this._util.getBundleString("mainframe.attackDefenseSlow.Lancer");
+						break;
+					default:
+						
+				}
+				treerow.push([ "xul:treecell", {label : unit} ]);
+			}
+			else {
+			    treerow.push([ "xul:treecell", {label : item[row]} ]);
+			}
+			
+		}
+		// generate treeitem element
         var treeitem = this._util.JSONToDOM([ "xul:treeitem", {}, treerow ], document, {});
         treeChildren.appendChild(treeitem);
-    }
+	}
 };
 
 /**

--- a/src/chrome/content/mainFrame.xul
+++ b/src/chrome/content/mainFrame.xul
@@ -290,47 +290,80 @@
 					<caption label="&mainframe.tabAttackDefenseSlow.criterion.label;"/>
 					<vbox flex="1">
 						<hbox align="center">
-							<label value="&mainframe.tabAttackDefenseSlow.castleLinkPrompt.label;" width="230"/>
+							<label value="&mainframe.tabAttackDefenseSlow.castleLinkPrompt.label;" width="170"/>
 							<textbox id="rigantestools-attackDefenseSlowTargetLink" value="" width="220" maxlength="40"/>
 							<spacer flex="1"/>
 						</hbox>
 						<hbox align="center">
-							<label value="&mainframe.tabAttackDefenseSlow.datetimePrompt.label;" width="230"/>
+							<label value="&mainframe.tabAttackDefenseSlow.datetimePrompt.label;" width="170"/>
 							<datepicker id="rigantestools-attackDefenseSlowDate" firstdayofweek="NaN" width="145" type="popup"/>
-							<label value="à"/>
+							<label value="&mainframe.tabAttackDefenseSlow.datetimePromptAt.label;"/>
 							<textbox id="rigantestools-attackDefenseSlowTime" width="50" value="20:00" maxlength="5"/>
 							<spacer width="20"/>
 							<label value="&mainframe.tabAttackDefenseSlow.durationPrompt.label;"/>
 							<textbox id="rigantestools-attackDefenseSlowDuration" value="03:00" width="50" maxlength="5"/>
+							<spacer width="20"/>
+							<checkbox id="rigantestools-defenseAttackDefenseSlowRalentit" checked="true" label="&mainframe.tabAttackDefenseSlow.useSlowers.label;" /> 						
 							<spacer flex="1"/>
 						</hbox>
 						<hbox align="center">
-							<label value="&mainframe.tabAttackDefenseSlow.datetimeStartUnitPrompt.label;" width="230"/>
-							<textbox id="rigantestools-attackDefenseSlowStartUnitTime" value="10:00" width="50" maxlength="5"/>
+							<label value="&mainframe.tabAttackDefenseSlow.datetimeStartUnitPrompt.label;" width="170"/>
+							<textbox id="rigantestools-attackDefenseSlowStartUnitTime" value="00:00" width="50" maxlength="5"/>
+							<spacer width="20"/>
+							<label value="&mainframe.tabAttackDefenseSlow.ErrorMargin.label;"/>
+							<menulist id="rigantestools-attackDefenseSlowErrorMargin">
+								<menupopup>
+							    	<menuitem label="0 min" value="0"/>
+							    	<menuitem label="1 min" value="1"/>
+							    	<menuitem label="2 min" value="2"/>
+							    	<menuitem label="3 min" value="3"/>
+							  	</menupopup>
+							</menulist>
 							<spacer flex="1"/>
+							
 						</hbox>
 						<hbox align="center">
-							<label value="&mainframe.tabAttackDefenseSlow.typeUnit.label;" width="230"/>
+							<label value="&mainframe.tabAttackDefenseSlow.typeUnit.label;" width="170"/>
 							<menulist id="rigantestools-attackDefenseSlowUnitType">
 								<menupopup>
-							    	<menuitem label="&mainframe.tabAttackDefenseSlow.typeUnitUD.label;" value="UD"/>
-							    	<menuitem label="&mainframe.tabAttackDefenseSlow.typeUnitUO.label;" value="UO"/>
-							    	<menuitem label="&mainframe.tabAttackDefenseSlow.typeUnitUD.label; + &mainframe.tabAttackDefenseSlow.typeUnitUO.label;" value="ALL"/>
+							    	<menuitem label="&mainframe.tabAttackDefenseSlow.typeUnit.UnitOnlyUD.label;" value="0"/>
+							    	<menuitem label="&mainframe.tabAttackDefenseSlow.typeUnit.UnitOnlyUO.label;" value="1"/>
+							    	<menuitem label="&mainframe.tabAttackDefenseSlow.typeUnit.UnitBoth.label;" value="2"/>
+							    	<menuitem label="&mainframe.tabAttackDefenseSlow.typeUnit.UnitBothButLancers.label;" value="3"/>
 							  	</menupopup>
 							</menulist>
-							<label value="&mainframe.tabAttackDefenseSlow.UnitCount.label;" width="74"/>
-							<menulist id="rigantestools-attackDefenseSlowUnitCount">
+							<label value="&mainframe.tabAttackDefenseSlow.UnitCount.label;"/>
+							<menulist id="rigantestools-attackDefenseSlowUnitCount" selectedIndex="3" value="200">
 								<menupopup>
-									<menuitem label="100" value="100"/>
-									<menuitem label="200" value="200"/>
-									<menuitem label="400" value="400"/>
+							    	<menuitem label="100+52  (10')" value="100"/>
+							    	<menuitem label="200+104 (10') SAFE" value="101"/>
+							    	<menuitem label="200+152 (15') SAFE" value="150"/>
+							    	<menuitem label="200+152 (20')" value="200"/>
+							    	<menuitem label="400+304 (20') SAFE" value="201"/>
+							    	<menuitem label="400+352 (30')" value="400"/>
+							  	</menupopup>
+							</menulist>
+							<label value="&mainframe.tabAttackDefenseSlow.MaxPerMinute.label;"/>
+							<menulist id="rigantestools-attackDefenseSlowMaxPerMinute" selectedIndex="3" value="3">
+								<menupopup>
+							    	<menuitem value="1" label="&mainframe.tabAttackDefenseSlow.MaxPerMinute.Min1.label;"/>
+							    	<menuitem value="2" label="&mainframe.tabAttackDefenseSlow.MaxPerMinute.Min2.label;"/>
+							    	<menuitem value="3" label="&mainframe.tabAttackDefenseSlow.MaxPerMinute.Min3.label;"/>
+							    	<menuitem value="4" label="&mainframe.tabAttackDefenseSlow.MaxPerMinute.Min4.label;"/>
+							    	<menuitem value="5" label="&mainframe.tabAttackDefenseSlow.MaxPerMinute.Min5.label;"/>
+							    	<menuitem value="6" label="&mainframe.tabAttackDefenseSlow.MaxPerMinute.Min6.label;"/>
 							  	</menupopup>
 							</menulist>
 							<spacer flex="1"/>
 						</hbox>
 						<hbox align="center">
-							<label value="&mainframe.tabAttackDefenseSlow.UsedAllCastles.label;" width="230"/>
-							<checkbox id="rigantestools-defenseAttackDefenseSlowUsedAllCastles" checked="false" /> 						
+							<label value="&mainframe.tabAttackDefenseSlow.UseOnlyCastles.label;" width="170"/>
+							<textbox id="rigantestools-attackDefenseSlowOnlyCastles" value="" width="180"/>
+							<spacer width="20"/>
+							<label value="&mainframe.tabAttackDefenseSlow.DoNotUseCastles.label;"/>
+							<textbox id="rigantestools-attackDefenseSlowNoCastles" value="" width="180"/>
+							<spacer width="20"/>
+							<checkbox id="rigantestools-defenseAttackDefenseSlowUsedAllCastles" checked="false" label="&mainframe.tabAttackDefenseSlow.UseAllCastles.label;" /> 						
 							<spacer flex="1"/>
 							<button id="rigantestools-attackDefenseSlowCalculateButton" label="&mainframe.tabAttackDefenseSlow.calculate.button;" oncommand="com.rigantestools.MainFrame.onCalculateAttackDefenseSlowButtonClick();"/>
 							<spacer width="10"/>
@@ -343,6 +376,7 @@
 					<treecol name="castle" label="&mainframe.tabAttackDefenseSlow.castle.label;" flex="4" ignoreincolumnpicker="true" persist="width ordinal" onclick="com.rigantestools.MainFrame.sortcolumnAttackDefenseSlowTree(this);" class="sortDirectionIndicator" sortDirection="natural"/>
 					<treecol name="unitType" label="&mainframe.tabAttackDefenseSlow.unitType.label;" flex="1" ignoreincolumnpicker="true" persist="width ordinal" onclick="com.rigantestools.MainFrame.sortcolumnAttackDefenseSlowTree(this);" class="sortDirectionIndicator" sortDirection="natural"/>
 					<treecol name="unitCount" label="&mainframe.tabAttackDefenseSlow.unitCount.label;" flex="1" ignoreincolumnpicker="true" persist="width ordinal" onclick="com.rigantestools.MainFrame.sortcolumnAttackDefenseSlowTree(this);" class="sortDirectionIndicator" sortDirection="natural"/>
+					<treecol name="ralentType" label="&mainframe.tabAttackDefenseSlow.slower.label;" flex="1" ignoreincolumnpicker="true" persist="width ordinal" onclick="com.rigantestools.MainFrame.sortcolumnAttackDefenseSlowTree(this);" class="sortDirectionIndicator" sortDirection="natural"/>
 					<treecol name="startDate" label="&mainframe.tabAttackDefenseSlow.startDateTime.label;" flex="2" ignoreincolumnpicker="true" persist="width ordinal" onclick="com.rigantestools.MainFrame.sortcolumnAttackDefenseSlowTree(this);" class="sortDirectionIndicator" sortDirection="natural"/>
 					<treecol name="ArrivalDatetime" label="&mainframe.tabAttackDefenseSlow.ArrivalDatetime.label;" flex="2" ignoreincolumnpicker="true" persist="width ordinal" onclick="com.rigantestools.MainFrame.sortcolumnAttackDefenseSlowTree(this);" class="sortDirectionIndicator" sortDirection="natural"/>
 				  </treecols>

--- a/src/chrome/locale/en-US/rigantestools.dtd
+++ b/src/chrome/locale/en-US/rigantestools.dtd
@@ -186,16 +186,31 @@
 <!ENTITY mainframe.tabAttackDefenseSlow.description "Screen to prepare a slow attack or defense in order to hold the longer face the enemy">
 <!ENTITY mainframe.tabAttackDefenseSlow.criterion.label "Criterion">
 <!ENTITY mainframe.tabAttackDefenseSlow.castleLinkPrompt.label "Link target castle :">
-<!ENTITY mainframe.tabAttackDefenseSlow.datetimePrompt.label "Date and time of attack (Start of round) :">
+<!ENTITY mainframe.tabAttackDefenseSlow.datetimePrompt.label "Date and time (of round) :">
+<!ENTITY mainframe.tabAttackDefenseSlow.datetimePromptAt.label "at">
 <!ENTITY mainframe.tabAttackDefenseSlow.durationPrompt.label "Duration :">
-<!ENTITY mainframe.tabAttackDefenseSlow.datetimeStartUnitPrompt.label "Max time to launch units before the attack :">
+<!ENTITY mainframe.tabAttackDefenseSlow.datetimeStartUnitPrompt.label "Send in">
+<!ENTITY mainframe.tabAttackDefenseSlow.useSlowers.label "Allow speed reducers">
 <!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.label "Unit type :">
-<!ENTITY mainframe.tabAttackDefenseSlow.typeUnitUO.label "UO">
-<!ENTITY mainframe.tabAttackDefenseSlow.typeUnitUD.label "UD">
-<!ENTITY mainframe.tabAttackDefenseSlow.UnitCount.label "Send by many :">
-<!ENTITY mainframe.tabAttackDefenseSlow.UsedAllCastles.label "Use also the castles attacked :">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.UnitOnlyUD.label "UD only">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.UnitOnlyUO.label "UO only">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.UnitBoth.label "UD+UO">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.UnitBothButLancers.label "UD+UO except lancers">
+<!ENTITY mainframe.tabAttackDefenseSlow.UnitCount.label "by packs of">
+<!ENTITY mainframe.tabAttackDefenseSlow.UseOnlyCastles.label "Use only these castles">
+<!ENTITY mainframe.tabAttackDefenseSlow.DoNotUseCastles.label "Do not use">
+<!ENTITY mainframe.tabAttackDefenseSlow.UseAllCastles.label "use attacked castles">
+<!ENTITY mainframe.tabAttackDefenseSlow.ErrorMargin.label "Error margin">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.label "Maximum of">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min1.label "1 per min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min2.label "2 per min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min3.label "3 per min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min4.label "4 per min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min5.label "5 per min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min6.label "6 per min">
 <!ENTITY mainframe.tabAttackDefenseSlow.calculate.button "Calculate">
 <!ENTITY mainframe.tabAttackDefenseSlow.castle.label "Castle">
+<!ENTITY mainframe.tabAttackDefenseSlow.slower.label "Reducer">
 <!ENTITY mainframe.tabAttackDefenseSlow.unitType.label "Unit">
 <!ENTITY mainframe.tabAttackDefenseSlow.unitCount.label "Number">
 <!ENTITY mainframe.tabAttackDefenseSlow.startDateTime.label "Start date and time">

--- a/src/chrome/locale/fr-FR/rigantestools.dtd
+++ b/src/chrome/locale/fr-FR/rigantestools.dtd
@@ -185,19 +185,34 @@
 <!ENTITY mainframe.tabAttackDefenseSlow.label "Attaque/défense lente">
 <!ENTITY mainframe.tabAttackDefenseSlow.description "Ecran permettant de préparer une attaque ou une défense lente afin de tenir le plus longtemps face à l'ennemi">
 <!ENTITY mainframe.tabAttackDefenseSlow.criterion.label "Critères">
-<!ENTITY mainframe.tabAttackDefenseSlow.castleLinkPrompt.label "Lien du château attaqué :">
-<!ENTITY mainframe.tabAttackDefenseSlow.datetimePrompt.label "Date et heure de l'attaque (Début de tour) :">
+<!ENTITY mainframe.tabAttackDefenseSlow.castleLinkPrompt.label "Lien du château attaqué">
+<!ENTITY mainframe.tabAttackDefenseSlow.datetimePrompt.label "Date et heure (du round)">
+<!ENTITY mainframe.tabAttackDefenseSlow.datetimePromptAt.label "�">
 <!ENTITY mainframe.tabAttackDefenseSlow.durationPrompt.label "Durée :">
-<!ENTITY mainframe.tabAttackDefenseSlow.datetimeStartUnitPrompt.label "Temps max de lancement des unités avant l'attaque :">
-<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.label "Type d'unité :">
-<!ENTITY mainframe.tabAttackDefenseSlow.typeUnitUO.label "UO">
-<!ENTITY mainframe.tabAttackDefenseSlow.typeUnitUD.label "UD">
-<!ENTITY mainframe.tabAttackDefenseSlow.UnitCount.label "Envoi par nombre de :">
-<!ENTITY mainframe.tabAttackDefenseSlow.UsedAllCastles.label "Utiliser aussi les châteaux attaqués :">
+<!ENTITY mainframe.tabAttackDefenseSlow.datetimeStartUnitPrompt.label "Envoyer dans">
+<!ENTITY mainframe.tabAttackDefenseSlow.useSlowers.label "Utiliser des ralentisseurs">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.label "Type d'unité">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.UnitOnlyUD.label "UD uniquement">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.UnitOnlyUO.label "UO uniquement">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.UnitBoth.label "UD+UO">
+<!ENTITY mainframe.tabAttackDefenseSlow.typeUnit.UnitBothButLancers.label "UD+UO sauf Lances">
+<!ENTITY mainframe.tabAttackDefenseSlow.UnitCount.label "par paquets de">
+<!ENTITY mainframe.tabAttackDefenseSlow.UseOnlyCastles.label "N'utiliser que les chateaux">
+<!ENTITY mainframe.tabAttackDefenseSlow.DoNotUseCastles.label "Ne pas utiliser">
+<!ENTITY mainframe.tabAttackDefenseSlow.UseAllCastles.label "Utiliser les châteaux attaqués">
+<!ENTITY mainframe.tabAttackDefenseSlow.ErrorMargin.label "Marge d'erreur">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.label "Maximum">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min1.label "1 par min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min2.label "2 par min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min3.label "3 par min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min4.label "4 par min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min5.label "5 par min">
+<!ENTITY mainframe.tabAttackDefenseSlow.MaxPerMinute.Min6.label "6 par min">
 <!ENTITY mainframe.tabAttackDefenseSlow.calculate.button "Calculer">
 <!ENTITY mainframe.tabAttackDefenseSlow.castle.label "Château">
 <!ENTITY mainframe.tabAttackDefenseSlow.unitType.label "Unité">
 <!ENTITY mainframe.tabAttackDefenseSlow.unitCount.label "Nombre">
+<!ENTITY mainframe.tabAttackDefenseSlow.slower.label "Ralentisseur">
 <!ENTITY mainframe.tabAttackDefenseSlow.startDateTime.label "Date et heure de départ">
 <!ENTITY mainframe.tabAttackDefenseSlow.ArrivalDatetime.label "Date et heure d'arrivée">
 <!ENTITY mainframe.tabAttackDefenseSlow.castleLink.label "Château attaqué :">


### PR DESCRIPTION
- use of speed reducers (e.g. send 152 riders with 1 lancer)
- limitation of number of sendings to N per minute (default 3)
- replaces "max time before attacks" by "send in". default 00:00 = send immediately
- configurable error marging (for landing time), 0, 1 or 2 minutes
- Added unit type "UD+UO, except lancers".
- Added packing options, especially 200+152 every 15 mins (safe mode)
- Added an option to omit certain castles (list of commas separated strings)
- Added an option to use only certain castles (same)
