### PR TITLE
Date display modifications:

### DIFF
--- a/src/chrome/content/mainFrame.js
+++ b/src/chrome/content/mainFrame.js
@@ -116,7 +116,7 @@ com.rigantestools.MainFrame.init = function() {
     
     this._util.setAttribute("rigantestools-playerName", "value", this._player.name);
     if(this._player.creationDate) {
-        this._util.setAttribute("rigantestools-playerCreationDate", "value", this._util.formatDateTime(new Date(this._player.creationDate)));
+        this._util.setAttribute("rigantestools-playerCreationDate", "value", this._util.formatDateTimeFull(new Date(this._player.creationDate)));
     }
     this._util.setAttribute("rigantestools-playerLink", "value", this._player.link);
     this._util.setAttribute("rigantestools-playerNbCastles", "value", this._player.getHabitatList().length);
@@ -2449,7 +2449,7 @@ com.rigantestools.MainFrame.refreshAttackDefenseSlowTree = function() {
         var treerow = [ "xul:treerow", { properties : properties }];
 		for (var row in item) {
 			if(row.indexOf("Date")>=0) { 
-				treerow.push([ "xul:treecell", {label : this._util.formatDateTime(item[row])} ]);
+				treerow.push([ "xul:treecell", {label : this._util.formatDayTime2(item[row])} ]);
 			} 
 			else if(row==="unitType" || row==="ralentUnitType"){
 				var unit = "";

--- a/src/modules/service/util.jsm
+++ b/src/modules/service/util.jsm
@@ -308,7 +308,7 @@ rigantestools_Util.prototype.secToTimeStr = function(time) {
  *            date date to convert in seconds.
  * @return {string} date in format jj.mm.aaaa hh:mm.
  */
-rigantestools_Util.prototype.formatDateTime = function(date) {
+rigantestools_Util.prototype.formatDateTimeFull = function(date) {
     if (date === null) {
         return "";
     }
@@ -325,6 +325,37 @@ rigantestools_Util.prototype.formatDateTime = function(date) {
     var f = (date.getMinutes() < 10) ? "0" + date.getMinutes() : date.getMinutes();
     return a + " " + b + "." + c + "." + d + " " + e + ":" + f;
 };
+
+
+/**
+ * convert seconds to datetime string jj.mm.aaaa hh:mm
+ * 
+ * @this {Util}
+ * @param {date}
+ *            date date to convert in seconds.
+ * @return {string} date in format jj.mm hh:mm.
+ */
+rigantestools_Util.prototype.formatDateTime = function(date) {
+    if (date === null) {
+        return "";
+    }
+
+    var day = date.getDay() - 1;
+    if (day < 0) {
+        day = 6;
+    }
+    var a = rigantestools_Util.prototype.getBundleString("smallDay." + day);
+    var b = (date.getDate() < 10) ? "0" + date.getDate() : date.getDate();
+    var c = ((date.getMonth() + 1) < 10) ? "0" + (date.getMonth() + 1) : (date.getMonth() + 1);
+    var e = (date.getHours() < 10) ? "0" + date.getHours() : date.getHours();
+    var f = (date.getMinutes() < 10) ? "0" + date.getMinutes() : date.getMinutes();
+    return a + " " + b + "." + c + "." + " " + e + ":" + f;
+};
+
+
+
+
+
 
 /**
  * convert seconds to time string day hh:mm
@@ -344,10 +375,54 @@ rigantestools_Util.prototype.formatDayTime = function(date) {
         day = 6;
     }
     var a = rigantestools_Util.prototype.getBundleString("smallDay." + day);
+    if( a.length==0 ) a = "?" ;
     var e = (date.getHours() < 10) ? "0" + date.getHours() : date.getHours();
     var f = (date.getMinutes() < 10) ? "0" + date.getMinutes() : date.getMinutes();
     return a + " " + e + ":" + f;
 };
+
+
+/**
+ * convert seconds to time string day hh:mm
+ * 
+ * @this {Util}
+ * @param {date}
+ *            date date to convert in seconds.
+ * @return {string} date in format day hh:mm except if today, in this case just hh:mm
+ */
+rigantestools_Util.prototype.formatDayTime2 = function(date) {
+    if (date === null) {
+        return "";
+    }
+
+    var day = date.getDay() - 1;
+    if (day < 0) {
+        day = 6;
+    }
+    
+    
+    var now = new Date();
+    var day2 = now.getDay() - 1;
+    if( day2 < 0 ) {
+    	day2 = 6 ;
+    }
+    
+    
+    var a = rigantestools_Util.prototype.getBundleString("smallDay." + day);
+    if( a.length==0 ) a = "?" ;
+    var e = (date.getHours() < 10) ? "0" + date.getHours() : date.getHours();
+    var f = (date.getMinutes() < 10) ? "0" + date.getMinutes() : date.getMinutes();
+    
+    
+    if( day===day2 ) {
+    	return e + ":" + f;
+    }
+    else {
+	    return a + " " + e + ":" + f;
+	}
+};
+
+
 
 rigantestools_Util.prototype.formatTime = function(date) {
     if (date === null) {


### PR DESCRIPTION
- year is ommited everywhere, e.g. 08/12 14:32 instead of 08/12/2014 14:32
- in Slow Defense tab, display (adaptive) short format, i.e. "sam 14:55" or just "14:55" if same day